### PR TITLE
Add after delayed processing

### DIFF
--- a/lib/delayed_paperclip.rb
+++ b/lib/delayed_paperclip.rb
@@ -10,6 +10,7 @@ module DelayedPaperclip
         :background_job_class => DelayedPaperclip::ProcessJob,
         :url_with_processing  => true,
         :processing_image_url => nil,
+        :after_delayed_processing => nil,
         :queue => "paperclip"
       }
     end
@@ -54,6 +55,7 @@ module DelayedPaperclip
         :only_process => only_process_default,
         :url_with_processing => DelayedPaperclip.options[:url_with_processing],
         :processing_image_url => DelayedPaperclip.options[:processing_image_url],
+        :after_delayed_processing => DelayedPaperclip.options[:after_delayed_processing],
         :queue => DelayedPaperclip.options[:queue]
       }.each do |option, default|
         paperclip_definitions[name][:delayed][option] = options.key?(option) ? options[option] : default

--- a/lib/delayed_paperclip/attachment.rb
+++ b/lib/delayed_paperclip/attachment.rb
@@ -53,12 +53,19 @@ module DelayedPaperclip
       reprocess!(*delayed_only_process)
       self.job_is_processing = false
       update_processing_column
+      instance.send("#{after_delayed_processing}") if after_delayed_processing.present?
     end
 
     def processing_image_url
       processing_image_url = delayed_options[:processing_image_url]
       processing_image_url = processing_image_url.call(self) if processing_image_url.respond_to?(:call)
       processing_image_url
+    end
+
+    def after_delayed_processing
+      after_delayed_processing = delayed_options[:after_delayed_processing]
+      after_delayed_processing = after_delayed_processing.call(self) if after_delayed_processing.respond_to?(:call)
+      after_delayed_processing
     end
 
     def save


### PR DESCRIPTION
**Card:** https://trello.com/c/64ecc3aafe6db4feb50b9e3c
### Problem
`paperclip` ships with a callback called `after_post_process` which should be called after processing is done. It turns out that `delayed_paperclip` does not work well with that callback. It appears that the paperclip calls the `after_post_process` synchronously as opposed to after the `delayed_paperclip` job is complete. 

### Solution
Add our own callback called `after_delayed_processing`, which will be called at the end of the `delayed_paperclip` job. Yay!

This is all in service of https://trello.com/c/YWOzPc1J/8090-3-stop-using-expiring-urls-to-serve-article-attachments